### PR TITLE
Code style definition

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+IndentWidth: 4
+AllowShortFunctionsOnASingleLine: Empty
+BreakBeforeBraces: Allman
+SpaceAfterControlStatementKeyword: true
+ColumnLimit: 120
+AllowShortIfStatementsOnASingleLine: false


### PR DESCRIPTION
The [.clang-format](https://github.com/TheEmperorsArmoury/TheGreatWar/commit/5c905e312a0d53258a667d89a838ca34a9ef1174) file is picked up by Visual Studio and ensures some sensible code-formatting rules are followed that are shared accross all devs.

See its docs [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

Its generally a good idea as it helps keep code style standardised accross the project.

Not, we can apply the style to files progressively, rather than agressively, as we code new and existing files, then the code will slowly formatted. This is better than formatting all the code in one PR as it causes conflicts and dev frurstration. Take one step at a time.